### PR TITLE
Update for D8 changes

### DIFF
--- a/default_content.services.yml
+++ b/default_content.services.yml
@@ -8,3 +8,7 @@ services:
   default_content.link_manager.relation:
       class: Drupal\default_content\LinkManager\RelationLinkManager
       arguments: ['@cache.cache', '@entity.manager']
+  default_content.entity_resolver.target_id:
+    class: Drupal\default_content\TargetIdResolver
+    tags:
+      - { name: entity_resolver}

--- a/lib/Drupal/default_content/DefaultContentManager.php
+++ b/lib/Drupal/default_content/DefaultContentManager.php
@@ -189,6 +189,7 @@ class DefaultContentManager implements DefaultContentManagerInterface {
 
   protected function resetTree() {
     $this->tree = FALSE;
+    $this->vertexes = array();
   }
 
   protected function sortTree() {

--- a/lib/Drupal/default_content/DefaultContentScanner.php
+++ b/lib/Drupal/default_content/DefaultContentScanner.php
@@ -7,27 +7,47 @@
 
 namespace Drupal\default_content;
 
-use \Drupal\Core\SystemListing;
-
 /**
  * A scanner to find YAML files in a given folder.
  */
-class DefaultContentScanner extends SystemListing {
+class DefaultContentScanner {
 
   /**
-   * {@inheritdoc}
+   * Returns a list of file objects.
+   *
+   * @param string $directory
+   *   Absolute path to the directory to search.
+   *
+   * @return array
+   *   List of stdClass objects with name and uri properties.
    */
-  public function scan($mask, $directory, $key = 'name') {
-    if (!in_array($key, array('uri', 'filename', 'name'))) {
-      $key = 'uri';
-    }
-    $directories = array($directory);
-    $nomask = '/^(CVS|lib|templates|css|js)$/';
+  public function scan($directory) {
+    // Use Unix paths regardless of platform, skip dot directories, follow
+    // symlinks (to allow extensions to be linked from elsewhere), and return
+    // the RecursiveDirectoryIterator instance to have access to getSubPath(),
+    // since SplFileInfo does not support relative paths.
+    $flags = \FilesystemIterator::UNIX_PATHS;
+    $flags |= \FilesystemIterator::SKIP_DOTS;
+    $flags |= \FilesystemIterator::CURRENT_AS_SELF;
+    $directory_iterator = new \RecursiveDirectoryIterator($directory, $flags);
+    $iterator = $iterator = new \RecursiveIteratorIterator($directory_iterator);
+
     $files = array();
-    // Get current list of items.
-    foreach ($directories as $dir) {
-      $files = array_merge($files, $this->process($files, $this->scanDirectory($dir, $key, $mask, $nomask)));
+    foreach ($iterator as $fileinfo) {
+      /* @var \SplFileInfo $fileinfo */
+
+      // Skip directories and non-json files.
+      if ($fileinfo->isDir() || $fileinfo->getExtension() != 'json') {
+        continue;
+      }
+
+      // @todo Use a typed class?
+      $file = new \stdClass();
+      $file->name = $fileinfo->getFilename();
+      $file->uri = $fileinfo->getPathname();
+      $files[$file->uri] = $file;
     }
+
     return $files;
   }
 

--- a/lib/Drupal/default_content/DefaultContentScanner.php
+++ b/lib/Drupal/default_content/DefaultContentScanner.php
@@ -30,7 +30,7 @@ class DefaultContentScanner {
     $flags |= \FilesystemIterator::SKIP_DOTS;
     $flags |= \FilesystemIterator::CURRENT_AS_SELF;
     $directory_iterator = new \RecursiveDirectoryIterator($directory, $flags);
-    $iterator = $iterator = new \RecursiveIteratorIterator($directory_iterator);
+    $iterator = new \RecursiveIteratorIterator($directory_iterator);
 
     $files = array();
     foreach ($iterator as $fileinfo) {

--- a/lib/Drupal/default_content/LinkManager/RelationLinkManager.php
+++ b/lib/Drupal/default_content/LinkManager/RelationLinkManager.php
@@ -47,19 +47,19 @@ class RelationLinkManager extends RestRelationLinkManager {
   protected function writeCache() {
     $data = array();
 
-    foreach ($this->entityManager->getDefinitions() as $entity_type => $entity_type_info) {
-      $reflection = new \ReflectionClass($entity_type_info['class']);
+    foreach ($this->entityManager->getDefinitions() as $entity_type_id => $entity_type) {
+      $reflection = new \ReflectionClass($entity_type->getClass());
       // We are only interested in importing content entities.
       if ($reflection->implementsInterface('\Drupal\Core\Config\Entity\ConfigEntityInterface') ||
         // @todo remove when Menu links are EntityNG.
          !$reflection->hasMethod('baseFieldDefinitions')) {
         continue;
       }
-      foreach (array_keys($this->entityManager->getBundleInfo($entity_type)) as $bundle) {
-        foreach ($this->entityManager->getFieldDefinitions($entity_type, $bundle) as $field_name => $field_details) {
-          $relation_uri = $this->getRelationUri($entity_type, $bundle, $field_name);
+      foreach (array_keys($this->entityManager->getBundleInfo($entity_type_id)) as $bundle) {
+        foreach ($this->entityManager->getFieldDefinitions($entity_type_id, $bundle) as $field_name => $field_details) {
+          $relation_uri = $this->getRelationUri($entity_type_id, $bundle, $field_name);
           $data[$relation_uri] = array(
-            'entity_type' => $entity_type,
+            'entity_type' => $entity_type_id,
             'bundle' => $bundle,
             'field_name' => $field_name,
           );

--- a/lib/Drupal/default_content/TargetIdResolver.php
+++ b/lib/Drupal/default_content/TargetIdResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\default_content\TargetIdResolver.
+ */
+
+namespace Drupal\default_content;
+
+use Drupal\serialization\EntityResolver\EntityResolverInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Resolves entities from data that contains an entity UUID.
+ */
+class TargetIdResolver implements EntityResolverInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolve(NormalizerInterface $normalizer, $data, $entity_type) {
+    if (isset($data['target_id'])) {
+      return $data['target_id'];
+    }
+    return NULL;
+  }
+
+}

--- a/lib/Drupal/default_content/Tests/DefaultContentTest.php
+++ b/lib/Drupal/default_content/Tests/DefaultContentTest.php
@@ -17,6 +17,9 @@ class DefaultContentTest extends WebTestBase {
    */
   public static $modules = array('rest', 'taxonomy', 'hal', 'default_content');
 
+  /**
+   * {@inheritdoc}
+   */
   public static function getInfo() {
     return array(
       'name' => 'Default content test',
@@ -25,6 +28,9 @@ class DefaultContentTest extends WebTestBase {
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp() {
     parent::setUp();
     $this->drupalCreateContentType(array('type' => 'page'));
@@ -43,6 +49,7 @@ class DefaultContentTest extends WebTestBase {
     $this->assertEqual($node->body->value, 'Crikey it works!');
     // Content is always imported as anonymous.
     $this->assertEqual($node->uid->target_id, 0);
+    $this->assertEqual($node->getType(), 'page');
     $terms = \Drupal::entityManager()->getStorageController('taxonomy_term')->loadMultiple();
     $term = reset($terms);
     $this->assertTrue(!empty($term));

--- a/tests/modules/default_content_test/content/node/imported.json
+++ b/tests/modules/default_content_test/content/node/imported.json
@@ -22,24 +22,14 @@
             }
         ]
     },
-    "nid": [
-        {
-            "value": "1"
-        }
-    ],
     "uuid": [
         {
             "value": "65c412a3-b83f-4efb-8a05-5a6ecea10ad4"
         }
     ],
-    "vid": [
-        {
-            "value": "1"
-        }
-    ],
     "type": [
         {
-            "value": "page"
+            "target_id": "page"
         }
     ],
     "langcode": [


### PR DESCRIPTION
Hi

Had to fix a few things to make it work again:
- entity info is now EntityTypeInterface
- SystemListing is gone, used a directory iterator instead similar to ExtensionDiscovery, just simpler, as we have no need for all the blacklisting and stuff IMHO
- Update the example to use target_id for the type, otherwise it saved an empty bundle.
- Directly save the entity instead of using $resource->post(). That does two things that we IMHO don't want to do here, a) permission checks (this should make the log in as admin part in the tests unecessary) and b) validation, which isn't of much use to us I think and we could still add it manually.

Test is still blocked on https://drupal.org/node/2135573.
