### PR TITLE
Add current object always to the graph

### DIFF
--- a/lib/Drupal/default_content/DefaultContentManager.php
+++ b/lib/Drupal/default_content/DefaultContentManager.php
@@ -119,6 +119,7 @@ class DefaultContentManager implements DefaultContentManagerInterface {
           $file_map[$self] = $file;
           // Create a vertex for the graph.
           $vertex = $this->getVertex($self);
+          $this->tree()->addVertex($vertex);
           if (empty($decoded['_embedded'])) {
             // No dependencies to resolve.
             continue;


### PR DESCRIPTION
More bugs :)

The object itself is not added to the graph if it does not have any dependencies or nothing depends on it.
