### PR TITLE
Remove unnecessary router rebuild.

### DIFF
--- a/default_content.module
+++ b/default_content.module
@@ -10,7 +10,6 @@
  */
 function default_content_modules_installed($modules) {
   // @todo Move this to an event once we have HookEvent.
-  \Drupal::service('router.builder')->rebuild();
   foreach ($modules as $module) {
     if (!\Drupal::isConfigSyncing()) {
       \Drupal::service('default_content.manager')->importContent($module);


### PR DESCRIPTION
With the lazy router rebuild changes, this does not seem to be necessary anymore, I can now install without errors with removing this and it saves a lot of router rebuilds, especially when installing with drush.
