### PR TITLE
Renamed taxonomy_term_reference to entity_reference, fixed test errors

### DIFF
--- a/tests/modules/default_content_test/config/install/field.field.node.page.field_tags.yml
+++ b/tests/modules/default_content_test/config/install/field.field.node.page.field_tags.yml
@@ -1,8 +1,6 @@
 id: node.page.field_tags
-uuid: F6002796-DE9D-4F8B-A8A5-693B7494C125
 status: true
 langcode: en
-field_uuid: A071BBC8-924B-4100-9BF4-3036D9BBDCF3
 field_name: field_tags
 entity_type: node
 bundle: page
@@ -11,8 +9,10 @@ description: 'Select the tag.'
 required: 1
 default_value: {  }
 default_value_function: ''
-settings: {  }
-field_type: taxonomy_term_reference
+settings:
+  bundles:
+    - tags
+field_type: entity_reference
 dependencies:
   config:
     - field.storage.node.field_tags

--- a/tests/modules/default_content_test/config/install/field.storage.node.field_tags.yml
+++ b/tests/modules/default_content_test/config/install/field.storage.node.field_tags.yml
@@ -3,12 +3,9 @@ status: true
 langcode: en
 field_name: field_tags
 entity_type: node
-type: taxonomy_term_reference
+type: entity_reference
 settings:
-  allowed_values:
-    -
-      vocabulary: tags
-      parent: '0'
+  target_type: taxonomy_term
   options_list_callback: null
 module: taxonomy
 active: true


### PR DESCRIPTION
The uid comparison is still failing and we are not sure why...
