### PR TITLE
Switched to Drupal_TI

### DIFF
--- a/.travis-before-install-script.sh
+++ b/.travis-before-install-script.sh
@@ -1,0 +1,4 @@
+if [ $(phpenv version-name) == '5.6' ]
+then
+  echo "always_populate_raw_post_data=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,98 +1,117 @@
+# @file
+# .travis.yml - Drupal for Travis CI Integration
+#
+# Template provided by https://github.com/LionsAd/drupal_ti.
+#
+# Based for simpletest upon:
+#   https://github.com/sonnym/travis-ci-drupal-module-example
+
 language: php
-cache:
-  bundler: true
-  directories:
-    - $HOME/tmp/drush
-    - $HOME/.bundle
-  apt: true
+
+sudo: false
 
 php:
-  - 5.6
   - 5.5
+  - 5.6
+  - 7
+  - hhvm
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 7
+    - php: hhvm
 
 env:
-  - PATH=$PATH:/home/travis/.composer/vendor/bin
+  global:
+    # add composer's global bin directory to the path
+    # see: https://github.com/drush-ops/drush#install---composer
+    - PATH="$PATH:$HOME/.composer/vendor/bin"
+
+    # Configuration variables.
+    - DRUPAL_TI_MODULE_NAME="default_content"
+    - DRUPAL_TI_SIMPLETEST_GROUP="default_content"
+
+    # Define runners and environment vars to include before and after the
+    # main runners / environment vars.
+    #- DRUPAL_TI_SCRIPT_DIR_BEFORE="./.drupal_ti/before"
+    #- DRUPAL_TI_SCRIPT_DIR_AFTER="./drupal_ti/after"
+
+    # The environment to use, supported are: drupal-7, drupal-8
+    - DRUPAL_TI_ENVIRONMENT="drupal-8"
+
+    # Drupal specific variables.
+    - DRUPAL_TI_DB="drupal_travis_db"
+    - DRUPAL_TI_DB_URL="mysql://root:@127.0.0.1/drupal_travis_db"
+    # Note: Do not add a trailing slash here.
+    - DRUPAL_TI_WEBSERVER_URL="http://127.0.0.1"
+    - DRUPAL_TI_WEBSERVER_PORT="8080"
+
+    # Simpletest specific commandline arguments, the DRUPAL_TI_SIMPLETEST_GROUP is appended at the end.
+    - DRUPAL_TI_SIMPLETEST_ARGS="--verbose --color --concurrency 4 --url $DRUPAL_TI_WEBSERVER_URL:$DRUPAL_TI_WEBSERVER_PORT"
+
+    # === Behat specific variables.
+    # This is relative to $TRAVIS_BUILD_DIR
+    - DRUPAL_TI_BEHAT_DIR="./tests/behat"
+    # These arguments are passed to the bin/behat command.
+    - DRUPAL_TI_BEHAT_ARGS=""
+    # Specify the filename of the behat.yml with the $DRUPAL_TI_DRUPAL_DIR variables.
+    - DRUPAL_TI_BEHAT_YML="behat.yml.dist"
+    # This is used to setup Xvfb.
+    - DRUPAL_TI_BEHAT_SCREENSIZE_COLOR="1280x1024x16"
+    # The version of seleniumthat should be used.
+    - DRUPAL_TI_BEHAT_SELENIUM_VERSION="2.44"
+    # Set DRUPAL_TI_BEHAT_DRIVER to "selenium" to use "firefox" or "chrome" here.
+    - DRUPAL_TI_BEHAT_DRIVER="phantomjs"
+    - DRUPAL_TI_BEHAT_BROWSER="firefox"
+
+    # PHPUnit specific commandline arguments.
+    - DRUPAL_TI_PHPUNIT_ARGS="--verbose --debug"
+    # Specifying the phpunit-core src/ directory is useful when e.g. a vendor/
+    # directory is present in the module directory, which phpunit would then
+    # try to find tests in. This option is relative to $TRAVIS_BUILD_DIR.
+    #- DRUPAL_TI_PHPUNIT_CORE_SRC_DIRECTORY="./tests/src"
+
+    # Code coverage via coveralls.io
+    - DRUPAL_TI_COVERAGE="satooshi/php-coveralls:0.6.*"
+    # This needs to match your .coveralls.yml file.
+    - DRUPAL_TI_COVERAGE_FILE="build/logs/clover.xml"
+
+    # Debug options
+    #- DRUPAL_TI_DEBUG="-x -v"
+    # Set to "all" to output all files, set to e.g. "xvfb selenium" or "selenium",
+    # etc. to only output those channels.
+    #- DRUPAL_TI_DEBUG_FILE_OUTPUT="selenium xvfb webserver"
+
+  matrix:
+    # [[[ SELECT ANY OR MORE OPTIONS ]]]
+    #- DRUPAL_TI_RUNNERS="phpunit"
+    #- DRUPAL_TI_RUNNERS="simpletest"
+    #- DRUPAL_TI_RUNNERS="behat"
+    - DRUPAL_TI_RUNNERS="phpunit-core simpletest"
 
 # This will create the database
 mysql:
-  database: drupal
+  database: drupal_travis_db
   username: root
   encoding: utf8
 
-# To be able to run a webbrowser
-# If we need anything more powerful
-# than e.g. phantomjs
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  - composer self-update
+  - composer global require "lionsad/drupal_ti:1.*"
+  # Can be removed after https://github.com/LionsAd/drupal_ti/pull/37 is merged.
+  - drupal-ti --include .travis-before-install-script.sh
+  -
+  - drupal-ti before_install
 
 install:
-  # Grab Drush
-  - composer global require drush/drush:dev-master --prefer-source
-  - cd /home/travis/.composer/vendor/drush/drush && cd -
-  # Make sure we don't fail when checking out projects
-  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-  # LAMP package installation (mysql is already started)
-  - sudo apt-get update
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
-  # enable php-fpm, travis does not support any other method with php and apache
-  - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-  - sudo a2enmod rewrite actions fastcgi alias
-  - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
-  # Make sure the apache root is in our wanted directory
-  - echo "$(curl -fsSL https://gist.githubusercontent.com/nickveenhof/11386315/raw/b8abaf9304fe12b5cc7752d39c29c1edae8ac2e6/gistfile1.txt)" | sed -e "s,PATH,$TRAVIS_BUILD_DIR/../drupal,g" | sudo tee /etc/apache2/sites-available/default > /dev/null
-  # Set sendmail so drush doesn't throw an error during site install.
-  - echo "sendmail_path='true'" >> `php --ini | grep "Loaded Configuration" | awk '{print $4}'`
-  # Forward the errors to the syslog so we can print them
-  - echo "error_log=syslog" >> `php --ini | grep "Loaded Configuration" | awk '{print $4}'`
-  # Get latest drupal 8 core
-  - cd $TRAVIS_BUILD_DIR/..
-  - git clone --depth 1 --branch 8.0.x http://git.drupal.org/project/drupal.git
-  # Restart apache and test it
-  - sudo service apache2 restart
-  - curl -v "http://localhost"
-  # Re-enable when trying to get CodeSniffer doesn't return a 403 anymore.
-  #- composer global require drupal/coder:\>7
+  - drupal-ti install
 
 before_script:
-  - cd $TRAVIS_BUILD_DIR/../drupal
-  # Update drupal core
-  - git pull origin 8.0.x
-  # Install the site
-  - drush -v site-install minimal --db-url=mysql://root:@localhost/drupal --yes
-  - drush en --yes simpletest
-  - drush cr
-  - phpenv rehash
+  - drupal-ti before_script
 
 script:
-  # go to our Drupal module directory
-  - mkdir $TRAVIS_BUILD_DIR/../drupal/modules/default_content
-  - cp -R $TRAVIS_BUILD_DIR/* $TRAVIS_BUILD_DIR/../drupal/modules/default_content/
-  # go to our Drupal main directory
-  - cd $TRAVIS_BUILD_DIR/../drupal
-  - ls -la $TRAVIS_BUILD_DIR/../drupal/sites/default
-  # Run the tests
-  - php core/scripts/run-tests.sh --verbose --color --concurrency 4 --php `which php` --url http://localhost "default_content" > /tmp/test.txt && TEST_EXIT=$?
-  - echo $TEST_EXIT
-  - cat /tmp/test.txt
-  # Check if we had fails in the run-tests.sh script
-  # Exit with the inverted value, because if there are no fails found, it will exit with 1 and for us that\
-  # is a good thing so invert it to 0. Travis has some issues with the exclamation mark in front so we have to fiddle a
-  # bit.
-  # Also make the grep case insensitive and fail on run-tests.sh regular fails as well on fatal errors.
-  - TEST_OUTPUT=$(! egrep -i "([0-9]+ fails)|(PHP Fatal error)|([0-9]+ exceptions)" /tmp/test.txt > /dev/null)$?
-  - echo $TEST_OUTPUT
-  #- cd $TRAVIS_BUILD_DIR/../drupal/core
-  #- ./vendor/bin/phpunit --verbose --debug ../modules/default_content/
-  #- TEST_PHPUNIT=$?
-  #- echo $TEST_PHPUNIT
-  # if the TEST_EXIT status is 0 AND the TEST_OUTPUT status is also 0 it means we succeeded, in all other cases we
-  # failed.
-  # Re-enable when trying to get CodeSniffer doesn't return a 403 anymore.
-  #- /home/travis/.composer/vendor/bin/phpcs --standard=/home/travis/.composer/vendor/drupal/coder/coder_sniffer/Drupal --extensions=php,inc,test,module,install --ignore=css/ $TRAVIS_BUILD_DIR/../drupal/modules/search_api
-  - php -i | grep 'php.ini'
-  - sudo cat /var/log/apache2/error.log
-  #- sudo cat /var/log/syslog | grep 'php'
-  # Exit the build
-  - if [ $TEST_EXIT -eq 0 ] && [ $TEST_OUTPUT -eq 0 ] ; then exit 0; else exit 1; fi
+  - drupal-ti script
+
+after_script:
+  - drupal-ti after_script


### PR DESCRIPTION
This pull request changes the .travis.yml to use the Drupal_TI template from https://github.com/LionsAd/drupal_ti. Take a look at the diff, removing a lot of complicated code and replacing it with a call to the corresponding drupal_ci function.
